### PR TITLE
Specify peer dependencies and build Docker images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,12 @@ jobs:
       - name: Run mllint tests
         run: ./test.sh
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build mllint & release to GitHub
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
 # This .goreleaser.yml file configures GoReleaser to properly and reproducibly build `mllint` for Linux, MacOS and Windows
+# It will also create a Docker container from the built executable and the given Dockerfile.
 before:
   hooks:
     - go mod tidy
@@ -13,6 +14,42 @@ builds:
     ldflags:
      - -s -w -X github.com/bvobart/mllint/commands.version={{.Version}} -X github.com/bvobart/mllint/commands.commit={{.Commit}} -X github.com/bvobart/mllint/commands.date={{.CommitDate}}
     mod_timestamp: '{{ .CommitTimestamp }}'
+
+# Build Docker containers of `mllint` for Python versions [3.6, 3.7, 3.8, 3.9]
+dockers:
+  - image_templates:
+      - bvobart/mllint:latest-py3.6
+      - bvobart/mllint:{{.Version}}-py3.6
+    build_flag_templates:
+      - --build-arg=python_version=3.6
+    extra_files:
+      - build/requirements-tools.txt
+
+  - image_templates:
+      - bvobart/mllint:latest-py3.7
+      - bvobart/mllint:{{.Version}}-py3.7
+    build_flag_templates:
+      - --build-arg=python_version=3.7
+    extra_files:
+      - build/requirements-tools.txt
+
+  - image_templates:
+      - bvobart/mllint:latest-py3.8
+      - bvobart/mllint:{{.Version}}-py3.8
+    build_flag_templates:
+      - --build-arg=python_version=3.8
+    extra_files:
+      - build/requirements-tools.txt
+
+  - image_templates:
+      - bvobart/mllint:latest
+      - bvobart/mllint:{{.Version}}
+      - bvobart/mllint:latest-py3.9
+      - bvobart/mllint:{{.Version}}-py3.9
+    build_flag_templates:
+      - --build-arg=python_version=3.9
+    extra_files:
+      - build/requirements-tools.txt
 
 archives:
   - format: tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+ARG python_version=3.9
+FROM python:${python_version}-alpine
+WORKDIR /mllint
+
+RUN apk update && apk add --no-cache gcc musl-dev python3-dev libffi-dev libgit2-dev
+
+COPY build/requirements-tools.txt .
+RUN pip install --no-cache-dir -r requirements-tools.txt
+
+COPY mllint .
+
+WORKDIR /app
+VOLUME /app
+ENTRYPOINT [ "/mllint/mllint" ]

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -38,7 +38,7 @@
 
 `mllint` is published to [PyPI](https://pypi.org/project/mllint/), so it can be installed globally or in your current environment using `pip`:
 ```sh
-pip install mllint
+pip install --upgrade mllint
 ```
 
 Alternatively, to add `mllint` to an existing project, if your project uses Poetry for its dependencies:
@@ -49,6 +49,24 @@ poetry add --dev mllint
 Or if your project uses Pipenv:
 ```sh
 pipenv install --dev mllint
+```
+
+### Tools
+
+`mllint` has a soft dependency on several Python tools that it uses for its analysis. While `mllint` will recommend that you place these tools in your project's development dependencies, these tools are listed as optional dependencies of `mllint` and can be installed along with `mllint` using:
+
+```sh
+pip install --upgrade mllint[tools]
+```
+
+### Docker
+
+There are also `mllint` Docker containers available on [Docker Hub](https://hub.docker.com/r/bvobart/mllint) at `bvobart/mllint` for Python 3.6, 3.7, 3.8 and 3.9. They require that you mount the folder with your project onto the container as a volume on `/app`.
+
+Here is an example of how to use this Docker container, assuming that your project is in the current folder. Replace `$(pwd)` with the full path to your project folder if it is somewhere else.
+
+```sh
+docker run -it --rm -v $(pwd):/app bvobart/mllint:latest
 ```
 
 ## Usage
@@ -104,8 +122,13 @@ To learn more about a certain rule or category, use `mllint describe` along with
 # Describe the Version Control category. This will also list the rules that it checks.
 mllint describe version-control
 
-# Describe the rule on DVC usage in the Version Control category
+# Use the exact slug of a rule to describe one rule,
+# e.g., the rule on DVC usage in the Version Control category
 mllint describe version-control/data/dvc
+
+# Use a partial slug to describe all rules whose slug starts with this snippet, 
+# e.g., all rules about version controlling data
+mllint describe version-control/data
 ```
 
 ---
@@ -139,6 +162,8 @@ rules:
     - version-control/code/git
     - dependency-management/single
 ```
+
+Similar to the `describe` command, this also matches partial slugs. So, to disable all rules regarding version controlling data, use `version-control/data`.
 
 #### TOML
 

--- a/build/requirements-tools.txt
+++ b/build/requirements-tools.txt
@@ -1,0 +1,6 @@
+dvc>=2.0.0
+pylint>=2.0.0
+mypy>=0.800
+black>=21.4b0
+isort>=5.0.0
+bandit>=1.6.2

--- a/build/setup.py
+++ b/build/setup.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import shutil
+
 import setuptools
 
 version = os.getenv("MLLINT_VERSION", "dev-snapshot")
@@ -112,6 +113,9 @@ shutil.copy2(exe_path, os.path.join('mllint', 'mllint-exe'))
 # Include ReadMe as long description
 with open("ReadMe.md", "r", encoding="utf-8") as fh:
   long_description = fh.read()
+# Include peer dependencies from requirements-tools.txt
+with open("requirements-tools.txt", "r", encoding="utf-8") as fh:
+  tools_require = fh.read().splitlines()
 
 setuptools.setup(
   name="mllint",
@@ -154,6 +158,7 @@ setuptools.setup(
   packages=['mllint'],
   package_data={'mllint': ['mllint-exe']},
   python_requires=">=3.6",
+  extras_require={'tools': tools_require},
   entry_points={
     'console_scripts': [
       'mllint=mllint.cli:main'


### PR DESCRIPTION
Hopefully, when this is merged and a tag is created for this, then Docker images for `mllint` will be published to `bvobart/mllint` on Docker Hub.

Also, it is now possible to do `pip install mllint[tools]` to install `mllint` along with all of the Python tools that it uses for its analysis. These are not actual dependencies of `mllint`, since `mllint` can run without them and not every project needs them, so they're optional dependencies. Additionally, we want users of `mllint` to place these dependencies in their own project by themselves. Sadly, the Python ecosystem doesn't have `peerDependencies` like NPM packages have, so optional dependencies is the best we can do.